### PR TITLE
Phase 2: code quality (ISAdefaults, ISAsubsetData, disp→fprintf, options.json)

### DIFF
--- a/CLOISTER.m
+++ b/CLOISTER.m
@@ -11,7 +11,7 @@ function out = CLOISTER(X, A, opts)
 %
 % -------------------------------------------------------------------------
 
-disp('  -> CLOISTER is using correlation to estimate a boundary for the space.');
+fprintf('  -> CLOISTER is using correlation to estimate a boundary for the space.\n');
 
 nfeats = size(X,2);
 [rho,pval] = corr(X);
@@ -29,7 +29,7 @@ if nfeats > MAX_FEATS
     Kedge = convhull(Zall(:,1), Zall(:,2));
     out.Zedge  = Zall(Kedge,:);
     out.Zecorr = out.Zedge;
-    disp('  -> CLOISTER has completed.');
+    fprintf('  -> CLOISTER has completed.\n');
     return;
 end
 % Pure-MATLAB replacement for de2bi (no Communications Toolbox required)
@@ -67,10 +67,10 @@ try
     Kecorr = convhull(Zecorr(:,1),Zecorr(:,2));
     out.Zecorr = Zecorr(Kecorr,:);
 catch
-    disp('  -> The acceptable correlation threshold was too strict.');
-    disp('  -> The features are weakely correlated.')
-    disp('  -> Please consider increasing it.');
+    fprintf('  -> The acceptable correlation threshold was too strict.\n');
+    fprintf('  -> The features are weakely correlated.\n');
+    fprintf('  -> Please consider increasing it.\n');
     out.Zecorr = out.Zedge;
 end
-disp('-------------------------------------------------------------------------');
-disp('  -> CLOISTER has completed.');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('  -> CLOISTER has completed.\n');

--- a/ISAdefaults.m
+++ b/ISAdefaults.m
@@ -1,0 +1,91 @@
+function opts = ISAdefaults(opts)
+% ISAdefaults  Fill in missing opts fields with default values.
+%   opts = ISAdefaults(opts) ensures every pipeline function receives a
+%   complete options struct, eliminating scattered isfield chains across
+%   buildIS, PILOT, TRACE, and CLOISTER. Call once at the buildIS entry
+%   point after loading options.json.
+
+% general
+if ~isfield(opts, 'general'),           opts.general           = struct; end
+if ~isfield(opts.general, 'seed'),      opts.general.seed      = 42;    end
+if ~isfield(opts.general, 'verbose'),   opts.general.verbose   = true;  end
+
+% perf
+if ~isfield(opts, 'perf'),                  opts.perf                  = struct; end
+if ~isfield(opts.perf, 'MaxPerf'),          opts.perf.MaxPerf          = false;  end
+if ~isfield(opts.perf, 'AbsPerf'),          opts.perf.AbsPerf          = false;  end
+if ~isfield(opts.perf, 'epsilon'),          opts.perf.epsilon          = 0.05;   end
+if ~isfield(opts.perf, 'betaThreshold'),    opts.perf.betaThreshold    = 0.55;   end
+
+% auto
+if ~isfield(opts, 'auto'),              opts.auto              = struct; end
+if ~isfield(opts.auto, 'preproc'),      opts.auto.preproc      = true;  end
+
+% bound
+if ~isfield(opts, 'bound'),             opts.bound             = struct; end
+if ~isfield(opts.bound, 'flag'),        opts.bound.flag        = true;  end
+
+% norm
+if ~isfield(opts, 'norm'),              opts.norm              = struct; end
+if ~isfield(opts.norm, 'flag'),         opts.norm.flag         = true;  end
+
+% selvars
+if ~isfield(opts, 'selvars'),                    opts.selvars                    = struct;     end
+if ~isfield(opts.selvars, 'smallscaleflag'),     opts.selvars.smallscaleflag     = false;      end
+if ~isfield(opts.selvars, 'smallscale'),         opts.selvars.smallscale         = 0.30;       end
+if ~isfield(opts.selvars, 'fileidxflag'),        opts.selvars.fileidxflag        = false;      end
+if ~isfield(opts.selvars, 'fileidx'),            opts.selvars.fileidx            = '';         end
+if ~isfield(opts.selvars, 'densityflag'),        opts.selvars.densityflag        = false;      end
+if ~isfield(opts.selvars, 'mindistance'),        opts.selvars.mindistance        = 0.10;       end
+if ~isfield(opts.selvars, 'type'),               opts.selvars.type               = 'Ftr&Good'; end
+
+% sifted
+if ~isfield(opts, 'sifted'),                opts.sifted                = struct; end
+if ~isfield(opts.sifted, 'flag'),           opts.sifted.flag           = true;   end
+if ~isfield(opts.sifted, 'rho'),            opts.sifted.rho            = 0.10;   end
+if ~isfield(opts.sifted, 'K'),              opts.sifted.K              = 10;     end
+if ~isfield(opts.sifted, 'NTREES'),         opts.sifted.NTREES         = 50;     end
+if ~isfield(opts.sifted, 'MaxIter'),        opts.sifted.MaxIter        = 1000;   end
+if ~isfield(opts.sifted, 'Replicates'),     opts.sifted.Replicates     = 100;    end
+
+% pilot
+if ~isfield(opts, 'pilot'),             opts.pilot             = struct; end
+if ~isfield(opts.pilot, 'analytic'),    opts.pilot.analytic    = false;  end
+if ~isfield(opts.pilot, 'ntries'),      opts.pilot.ntries      = 10;     end
+if ~isfield(opts.pilot, 'ISA3D'),       opts.pilot.ISA3D       = false;  end
+if ~isfield(opts.pilot, 'verbose'),     opts.pilot.verbose     = opts.general.verbose; end
+
+% cloister
+if ~isfield(opts, 'cloister'),          opts.cloister          = struct; end
+if ~isfield(opts.cloister, 'pval'),     opts.cloister.pval     = 0.05;   end
+if ~isfield(opts.cloister, 'cthres'),   opts.cloister.cthres   = 0.70;   end
+
+% pythia
+if ~isfield(opts, 'pythia'),                opts.pythia                = struct; end
+if ~isfield(opts.pythia, 'flag'),           opts.pythia.flag           = true;   end
+if ~isfield(opts.pythia, 'useknn'),         opts.pythia.useknn         = false;  end
+if ~isfield(opts.pythia, 'cvfolds'),        opts.pythia.cvfolds        = 5;      end
+if ~isfield(opts.pythia, 'ispolykrnl'),     opts.pythia.ispolykrnl     = false;  end
+if ~isfield(opts.pythia, 'useweights'),     opts.pythia.useweights     = false;  end
+if ~isfield(opts.pythia, 'uselibsvm'),      opts.pythia.uselibsvm      = false;  end
+if ~isfield(opts.pythia, 'verbose'),        opts.pythia.verbose        = opts.general.verbose; end
+
+% trace
+if ~isfield(opts, 'trace'),             opts.trace             = struct; end
+if ~isfield(opts.trace, 'usesim'),      opts.trace.usesim      = false;  end
+if ~isfield(opts.trace, 'PI'),          opts.trace.PI          = 0.75;   end
+if ~isfield(opts.trace, 'RHO'),         opts.trace.RHO         = 10;     end
+if ~isfield(opts.trace, 'Trace2'),      opts.trace.Trace2      = false;  end
+
+% outputs
+if ~isfield(opts, 'outputs'),           opts.outputs           = struct; end
+if ~isfield(opts.outputs, 'csv'),       opts.outputs.csv       = true;   end
+if ~isfield(opts.outputs, 'png'),       opts.outputs.png       = true;   end
+if ~isfield(opts.outputs, 'web'),       opts.outputs.web       = false;  end
+
+% parallel
+if ~isfield(opts, 'parallel'),          opts.parallel          = struct; end
+if ~isfield(opts.parallel, 'flag'),     opts.parallel.flag     = false;  end
+if ~isfield(opts.parallel, 'ncores'),   opts.parallel.ncores   = 18;     end
+
+end

--- a/ISAsubsetData.m
+++ b/ISAsubsetData.m
@@ -1,0 +1,22 @@
+function data = ISAsubsetData(data, subsetIndex, featIdx)
+% ISAsubsetData  Subset rows (and optionally feature columns) of a data struct.
+%   data = ISAsubsetData(data, subsetIndex) subsets all row-indexed fields.
+%   data = ISAsubsetData(data, subsetIndex, featIdx) also selects feature
+%   columns featIdx from data.X (used in the post-SIFTED density path).
+if nargin < 3
+    featIdx = ':';
+end
+data.X            = data.X(subsetIndex, featIdx);
+data.Y            = data.Y(subsetIndex, :);
+data.Xraw         = data.Xraw(subsetIndex, :);
+data.Yraw         = data.Yraw(subsetIndex, :);
+data.Ybin         = data.Ybin(subsetIndex, :);
+data.beta         = data.beta(subsetIndex);
+data.numGoodAlgos = data.numGoodAlgos(subsetIndex);
+data.Ybest        = data.Ybest(subsetIndex);
+data.P            = data.P(subsetIndex);
+data.instlabels   = data.instlabels(subsetIndex);
+if isfield(data, 'S')
+    data.S = data.S(subsetIndex);
+end
+end

--- a/PILOT.m
+++ b/PILOT.m
@@ -1,4 +1,5 @@
 function out = PILOT(X, Y, featlabels, opts)
+if ~isfield(opts, 'verbose'), opts.verbose = true; end
 % -------------------------------------------------------------------------
 % PILOT.m
 % -------------------------------------------------------------------------
@@ -42,8 +43,8 @@ if opts.analytic && rank(X) < size(X,2)
 end
 
 if opts.analytic && ~opts.ISA3D
-    disp('  -> PILOT is solving analyticaly the projection problem.');
-    disp('  -> This won''t take long.');
+    fprintf('  -> PILOT is solving analyticaly the projection problem.\n');
+    fprintf('  -> This won''t take long.\n');
     Xbar = Xbar';
     X = X';
     [V,D] = eig(Xbar*Xbar');
@@ -60,34 +61,34 @@ if opts.analytic && ~opts.ISA3D
 else
     if isfield(opts,'alpha') && isnumeric(opts.alpha) && ...
                 size(opts.alpha,1)==2*m+2*n && size(opts.alpha,2)==1
-        disp('  -> PILOT is using a pre-calculated solution.');
+        fprintf('  -> PILOT is using a pre-calculated solution.\n');
         idx = 1;
         out.alpha = opts.alpha;
     elseif isfield(opts,'alpha') && isnumeric(opts.alpha) && opts.ISA3D && ...
                 size(opts.alpha,1)==3*m+3*n && size(opts.alpha,2)==1
-        disp('  -> PILOT3D is using a pre-calculated solution.');
+        fprintf('  -> PILOT3D is using a pre-calculated solution.\n');
         idx = 1;
         out.alpha = opts.alpha; 
     else
         if isfield(opts,'X0') && isnumeric(opts.X0) && ...
                 size(opts.X0,1)==2*m+2*n && size(opts.X0,2)>=1
-            disp('  -> PILOT is using a user defined starting points for BFGS.');
+            fprintf('  -> PILOT is using a user defined starting points for BFGS.\n');
             X0 = opts.X0;
             opts.ntries = size(opts.X0,2);
         elseif isfield(opts,'X0') && isnumeric(opts.X0) && opts.ISA3D && ...
                 size(opts.X0,1)==3*m+3*n && size(opts.X0,2)>=1
-            disp('  -> PILOT3D is using a user defined starting points for BFGS.');
+            fprintf('  -> PILOT3D is using a user defined starting points for BFGS.\n');
             X0 = opts.X0;
             opts.ntries = size(opts.X0,2);
         else
-            if opts.ISA3D 
-                disp('  -> PILOT3D is using a random starting points for BFGS.');
+            if opts.ISA3D
+                fprintf('  -> PILOT3D is using a random starting points for BFGS.\n');
                 state = rng;
                 rng('default');
                 X0 = 2*rand(3*m+3*n, opts.ntries)-1;
                 rng(state);
             else
-                disp('  -> PILOT is using a random starting points for BFGS.');
+                fprintf('  -> PILOT is using a random starting points for BFGS.\n');
                 state = rng;
                 rng('default');
                 X0 = 2*rand(2*m+2*n, opts.ntries)-1;
@@ -101,10 +102,10 @@ else
         end
         eoptim = zeros(1, opts.ntries);
         perf = zeros(1, opts.ntries);
-        disp('-------------------------------------------------------------------------');
-        disp('  -> PILOT is solving numerically the projection problem.');
-        disp('  -> This may take a while. Trials will not be run sequentially.');
-        disp('-------------------------------------------------------------------------');
+        fprintf('-------------------------------------------------------------------------\n');
+        fprintf('  -> PILOT is solving numerically the projection problem.\n');
+        fprintf('  -> This may take a while. Trials will not be run sequentially.\n');
+        fprintf('-------------------------------------------------------------------------\n');
         parfor (i=1:opts.ntries,nworkers)
             [alpha(:,i),eoptim(i)] = fminunc(errorfcn, X0(:,i), ...
                                              optimoptions('fminunc','Algorithm','quasi-newton',...
@@ -119,7 +120,9 @@ else
             end
             Z = X*A';
             perf(i) = corr(Hd,pdist(Z)');
-            disp(['    -> PILOT has completed trial ' num2str(i)]);
+            if opts.verbose
+                fprintf('    -> PILOT has completed trial %d\n', i);
+            end
         end
         out.X0 = X0;
         out.alpha = alpha;
@@ -148,8 +151,8 @@ else
     end
 end
 
-disp('-------------------------------------------------------------------------');
-disp('  -> PILOT has completed. The projection matrix A is:');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('  -> PILOT has completed. The projection matrix A is:\n');
 if opts.ISA3D 
     out.summary = cell(4, n+1);
 else
@@ -158,7 +161,7 @@ end
 out.summary(1,2:end) = featlabels;
 out.summary(2:end,1) = {'Z_{1}','Z_{2}'};
 out.summary(2:end,2:end) = num2cell(round(out.A,4));
-disp(' ');
+fprintf('\n');
 disp(out.summary);
 
 end

--- a/PRELIM.m
+++ b/PRELIM.m
@@ -9,8 +9,8 @@ nalgos = size(Y,2);
 % algorithm has a performance better than the threshold) or a relative
 % performance (the algorithm has a performance that is similar that the
 % best algorithm minus a percentage).
-disp('-------------------------------------------------------------------------');
-disp('-> Calculating the binary measure of performance');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('-> Calculating the binary measure of performance\n');
 msg = '-> An algorithm is good if its performace is ';
 if opts.MaxPerf
     Yaux = Y;
@@ -41,7 +41,7 @@ else
         msg = [msg 'within ' num2str(round(100.*opts.epsilon)) '% of the best.'];
     end
 end
-disp(msg);
+fprintf('%s\n', msg);
 % -------------------------------------------------------------------------
 % Testing for ties. If there is a tie in performance, we pick an algorithm
 % at random.
@@ -54,22 +54,22 @@ for i=1:size(Y,1)
         P(i) = aux(randi(length(aux),1)); % Pick one at random
     end
 end
-disp(['-> For ' num2str(round(100.*mean(multipleBestAlgos))) '% of the instances there is ' ...
-      'more than one best algorithm. Random selection is used to break ties.']);
+fprintf('-> For %s%% of the instances there is more than one best algorithm. Random selection is used to break ties.\n', ...
+    num2str(round(100.*mean(multipleBestAlgos))));
 numGoodAlgos = sum(Ybin,2);
 beta = numGoodAlgos>(opts.betaThreshold*nalgos);
 
 if opts.auto
-    disp('=========================================================================');
-    disp('-> Auto-pre-processing.');
-    disp('=========================================================================');
+    fprintf('=========================================================================\n');
+    fprintf('-> Auto-pre-processing.\n');
+    fprintf('=========================================================================\n');
 end
 out.medval = nanmedian(X, 1);
 out.iqrange = iqr(X, 1);
 out.hibound = out.medval + 5.*out.iqrange;
 out.lobound = out.medval - 5.*out.iqrange;
 if opts.auto && opts.bound
-    disp('-> Removing extreme outliers from the feature values.');
+    fprintf('-> Removing extreme outliers from the feature values.\n');
     himask = bsxfun(@gt,X,out.hibound);
     lomask = bsxfun(@lt,X,out.lobound);
     X = X.*~(himask | lomask) + bsxfun(@times,himask,out.hibound) + ...
@@ -87,7 +87,7 @@ out.lambdaY = zeros(1,nalgos);
 out.muY = zeros(1,nalgos);
 out.sigmaY = zeros(1,nalgos);
 if opts.auto && opts.norm
-    disp('-> Auto-normalizing the data using Box-Cox and Z transformations.');
+    fprintf('-> Auto-normalizing the data using Box-Cox and Z transformations.\n');
     X = bsxfun(@minus,X,out.minX)+1;
     for i=1:nfeats
         aux = X(:,i);

--- a/PYTHIA.m
+++ b/PYTHIA.m
@@ -1,4 +1,5 @@
 function out = PYTHIA(Z, Y, Ybin, Ybest, algolabels, opts)
+if ~isfield(opts, 'verbose'), opts.verbose = true; end
 % -------------------------------------------------------------------------
 % PYTHIA.m
 % -------------------------------------------------------------------------
@@ -11,7 +12,7 @@ function out = PYTHIA(Z, Y, Ybin, Ybest, algolabels, opts)
 %
 % -------------------------------------------------------------------------
 
-disp('  -> Initializing PYTHIA.');
+fprintf('  -> Initializing PYTHIA.\n');
 [Znorm,out.mu,out.sigma] = zscore(Z);
 [ninst,nalgos] = size(Ybin);
 out.cp = cell(1,nalgos);
@@ -23,7 +24,7 @@ out.Pr0sub = 0.*Ybin;
 out.Pr0hat = 0.*Ybin;
 out.boxcosnt = zeros(1,nalgos);
 out.kscale = out.boxcosnt;
-disp('-------------------------------------------------------------------------');
+fprintf('-------------------------------------------------------------------------\n');
 precalcparams = isfield(opts,'params') && isnumeric(opts.params) && ...
                 size(opts.params,1)==nalgos && size(opts.params,2)==2;
 params = NaN.*ones(nalgos,2);
@@ -31,47 +32,46 @@ if opts.ispolykrnl
     KernelFcn = 'polynomial';
 else
     if ninst>1e3
-        disp('  -> For datasets larger than 1K Instances, PYTHIA works better with a Polynomial kernel.');
-        disp('  -> Consider changing the kernel if the results are unsatisfactory.');
-        disp('-------------------------------------------------------------------------');
+        fprintf('  -> For datasets larger than 1K Instances, PYTHIA works better with a Polynomial kernel.\n');
+        fprintf('  -> Consider changing the kernel if the results are unsatisfactory.\n');
+        fprintf('-------------------------------------------------------------------------\n');
     end
     KernelFcn = 'gaussian';
 end
-disp(['  -> PYTHIA is using a ' KernelFcn ' kernel ']);
-disp('-------------------------------------------------------------------------');
+fprintf('  -> PYTHIA is using a %s kernel\n', KernelFcn);
+fprintf('-------------------------------------------------------------------------\n');
 if opts.uselibsvm
-    disp('  -> Using LIBSVM''s libraries.');
+    fprintf('  -> Using LIBSVM''s libraries.\n');
     if precalcparams
-        disp('  -> Using pre-calculated hyper-parameters for the SVM.');
+        fprintf('  -> Using pre-calculated hyper-parameters for the SVM.\n');
         params = opts.params;
     else
-        disp('  -> Search on a latin hyper-cube design will be used for parameter hyper-tunning.');
+        fprintf('  -> Search on a latin hyper-cube design will be used for parameter hyper-tunning.\n');
     end
 else
-    disp('  -> Using MATLAB''s SVM libraries.');
+    fprintf('  -> Using MATLAB''s SVM libraries.\n');
     if precalcparams
-        disp('  -> Using pre-calculated hyper-parameters for the SVM.');
+        fprintf('  -> Using pre-calculated hyper-parameters for the SVM.\n');
         params = opts.params;
     else
-        disp('  -> Bayesian Optimization will be used for parameter hyper-tunning.');
+        fprintf('  -> Bayesian Optimization will be used for parameter hyper-tunning.\n');
     end
-    disp('-------------------------------------------------------------------------');
+    fprintf('-------------------------------------------------------------------------\n');
     if opts.useweights
-        disp('  -> PYTHIA is using cost-sensitive classification');
+        fprintf('  -> PYTHIA is using cost-sensitive classification\n');
         out.W = abs(Y-nanmean(Y(:)));
         out.W(out.W==0) = min(out.W(out.W~=0));
         out.W(isnan(out.W)) = max(out.W(~isnan(out.W)));
         Waux = out.W;
     else
-        disp('  -> PYTHIA is not using cost-sensitive classification');
+        fprintf('  -> PYTHIA is not using cost-sensitive classification\n');
         Waux = ones(ninst,nalgos);
     end
 end
-disp('-------------------------------------------------------------------------');
-disp(['  -> Using a ' num2str(opts.cvfolds) ...
-      '-fold stratified cross-validation experiment to evaluate the SVMs.']);
-disp('-------------------------------------------------------------------------');
-disp('  -> Training has started. PYTHIA may take a while to complete...');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('  -> Using a %d-fold stratified cross-validation experiment to evaluate the SVMs.\n', opts.cvfolds);
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('  -> Training has started. PYTHIA may take a while to complete...\n');
 t = tic;
 for i=1:nalgos
     tic;
@@ -109,17 +109,16 @@ for i=1:nalgos
         end
     end
 	out.cvcmat(i,:) = aux(:);
-    if i==nalgos
-        disp(['    -> PYTHIA has trained a model for ''' algolabels{i}, ...
-              ''', there are no models left to train.']);
-    elseif i==nalgos-1
-        disp(['    -> PYTHIA has trained a model for ''' algolabels{i}, ...
-              ''', there is 1 model left to train.']);
-    else
-        disp(['    -> PYTHIA has trained a model for ''' algolabels{i}, ...
-              ''', there are ' num2str(nalgos-i) ' models left to train.']);
+    if opts.verbose
+        if i==nalgos
+            fprintf('    -> PYTHIA has trained a model for ''%s'', there are no models left to train.\n', algolabels{i});
+        elseif i==nalgos-1
+            fprintf('    -> PYTHIA has trained a model for ''%s'', there is 1 model left to train.\n', algolabels{i});
+        else
+            fprintf('    -> PYTHIA has trained a model for ''%s'', there are %d models left to train.\n', algolabels{i}, nalgos-i);
+        end
+        fprintf('      -> Elapsed time: %.2fs\n', toc);
     end
-    disp(['      -> Elapsed time: ' num2str(toc,'%.2f\n') 's']);
 end
 tn = out.cvcmat(:,1);
 fp = out.cvcmat(:,3);
@@ -128,14 +127,12 @@ tp = out.cvcmat(:,4);
 out.precision = tp./(tp+fp);
 out.recall = tp./(tp+fn);
 out.accuracy = (tp+tn)./ninst;
-disp('-------------------------------------------------------------------------');
-disp('  -> PYTHIA has completed training the models.');
-disp(['  -> The average cross validated precision is: ' ...
-      num2str(round(100.*mean(out.precision),1)) '%']);
-disp(['  -> The average cross validated accuracy is: ' ...
-      num2str(round(100.*mean(out.accuracy),1)) '%']);
-  disp(['      -> Elapsed time: ' num2str(toc(t),'%.2f\n') 's']);
-disp('-------------------------------------------------------------------------');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('  -> PYTHIA has completed training the models.\n');
+fprintf('  -> The average cross validated precision is: %s%%\n', num2str(round(100.*mean(out.precision),1)));
+fprintf('  -> The average cross validated accuracy is: %s%%\n', num2str(round(100.*mean(out.accuracy),1)));
+fprintf('      -> Elapsed time: %.2fs\n', toc(t));
+fprintf('-------------------------------------------------------------------------\n');
 % We assume that the most precise SVM (as per CV-Precision) is the most
 % reliable.
 if nalgos>1
@@ -166,7 +163,7 @@ tg = sum(any( Ybin &  sel0,2));
 precisionsel = tg./(tg+fg);
 recallsel = tg./(tg+fb);
 
-disp('  -> PYTHIA is preparing the summary table.');
+fprintf('  -> PYTHIA is preparing the summary table.\n');
 out.summary = cell(nalgos+3, 11);
 out.summary{1,1} = 'Algorithms ';
 out.summary(2:end-2, 1) = algolabels;
@@ -192,8 +189,8 @@ out.summary(2:end, 9) = num2cell(round(100.*[out.recall' NaN recallsel],1));
 out.summary(2:end-2, 10) = num2cell(round(out.boxcosnt,3));
 out.summary(2:end-2, 11) = num2cell(round(out.kscale,3));
 out.summary(cellfun(@(x) all(isnan(x)),out.summary)) = {[]}; % Clean up. Not really needed
-disp('  -> PYTHIA has completed! Performance of the models:');
-disp(' ');
+fprintf('  -> PYTHIA has completed! Performance of the models:\n');
+fprintf('\n');
 disp(out.summary);
 
 end

--- a/SIFTED2.m
+++ b/SIFTED2.m
@@ -40,12 +40,12 @@ nfeats = size(X,2);
 if nfeats<=1
     error('-> There is only 1 feature. Stopping space construction.');
 elseif nfeats<=3
-    disp('-> There are 3 or less features to do selection. Skipping feature selection.')
+    fprintf('-> There are 3 or less features to do selection. Skipping feature selection.\n')
     out.selvars = 1:nfeats;
     return;
 end
 % ---------------------------------------------------------------------
-disp('-> Selecting features based on correlation with performance.');
+fprintf('-> Selecting features based on correlation with performance.\n');
 [out.rho,out.p] = corr(X,Y,'rows','pairwise');
 rho = out.rho;
 rho(isnan(rho) | (out.p>alphaval)) = 0;
@@ -59,34 +59,34 @@ for ii=2:nfeats
 end
 out.selvars = find(out.selvars);
 Xaux = X(:,out.selvars);
-disp(['-> Keeping ' num2str(size(Xaux,2)) ' out of ' num2str(nfeats) ' features (correlation).']);
+fprintf('-> Keeping %d out of %d features (correlation).\n', size(Xaux,2), nfeats);
 % ---------------------------------------------------------------------
 nfeats = size(Xaux,2);
 if nfeats<=1
     error('-> There is only 1 feature. Stopping space construction.');
 elseif nfeats<=3
-    disp('-> There are 3 or less features to do selection. Skipping correlation clustering selection.');
+    fprintf('-> There are 3 or less features to do selection. Skipping correlation clustering selection.\n');
     X = Xaux;
     return;
 elseif nfeats<=opts.K
-    disp('-> There are less or equal features than clusters. Skipping correlation clustering selection.');
+    fprintf('-> There are less or equal features than clusters. Skipping correlation clustering selection.\n');
     X = Xaux;
     return;
 end
 % ---------------------------------------------------------------------
-disp('-> Selecting features based on correlation clustering.');
+fprintf('-> Selecting features based on correlation clustering.\n');
 state = rng;
 rng('default');
 out.eva = evalclusters(Xaux', 'kmeans', 'Silhouette', 'KList', 3:nfeats, ... % minimum of three features
                               'Distance', 'correlation');
-disp('-> Average silhouette values for each number of clusters.')
+fprintf('-> Average silhouette values for each number of clusters.\n')
 disp([out.eva.InspectedK; out.eva.CriterionValues]);
 if out.eva.CriterionValues(out.eva.InspectedK==opts.K)<innaceptableClustering
-    disp(['-> The silhouette value for K=' num2str(opts.K) ...
-          ' is below ' num2str(innaceptableClustering) '. You should consider increasing K.']);
+    fprintf('-> The silhouette value for K=%d is below %s. You should consider increasing K.\n', ...
+        opts.K, num2str(innaceptableClustering));
     out.Ksuggested = out.eva.InspectedK(find(out.eva.CriterionValues>acceptableClustering,1));
     if ~isempty(out.Ksuggested)
-        disp(['-> A suggested value of K is ' num2str(out.Ksuggested)]);
+        fprintf('-> A suggested value of K is %d\n', out.Ksuggested);
     end
 end
 % ---------------------------------------------------------------------
@@ -97,8 +97,8 @@ out.clust = bsxfun(@eq, kmeans(Xaux', opts.K, 'Distance', 'correlation', ...
                                               'Options', statset('UseParallel', nworkers~=0), ...
                                               'OnlinePhase', 'on'), 1:opts.K);
 rng(state);
-disp(['-> Constructing ' num2str(opts.K) ' clusters of features.']);
-disp('-> Using a GA+LookUpTable to find an optimal combination.');
+fprintf('-> Constructing %d clusters of features.\n', opts.K);
+fprintf('-> Using a GA+LookUpTable to find an optimal combination.\n');
 % ---------------------------------------------------------------------
 cvpart = cvpartition(size(Xaux,1), 'Kfold', Kfolds);
 fcnwrap = @(x) costfcn(x, Xaux, Y, Ybin, out.clust, cvpart, featlabels, nworkers);
@@ -114,7 +114,7 @@ for i=1:opts.K
 end
 out.selvars = out.selvars(decoder);
 X = X(:,out.selvars);
-disp(['-> Keeping ' num2str(size(X, 2)) ' out of ' num2str(nfeats) ' features (clustering).']);
+fprintf('-> Keeping %d out of %d features (clustering).\n', size(X,2), nfeats);
 
 end
 % =========================================================================

--- a/TRACE.m
+++ b/TRACE.m
@@ -10,8 +10,8 @@ function out = TRACE(Z, Ybin, P, beta, algolabels, opts)
 %     2020
 %
 % -------------------------------------------------------------------------
-if size(Z,2) == 3 
-    disp('  -> 3D Instance Space detected using TRACE2');
+if size(Z,2) == 3
+    fprintf('  -> 3D Instance Space detected using TRACE2\n');
     opts.Trace2 = true;
 end
 
@@ -30,9 +30,9 @@ end
 % calculate the 'space' footprint. This is also the maximum area possible
 % for a footprint.
 if opts.Trace2
-    disp('  -> TRACE2 is calculating the space area and density.');
+    fprintf('  -> TRACE2 is calculating the space area and density.\n');
 else
-    disp('  -> TRACE is calculating the space area and density.');
+    fprintf('  -> TRACE is calculating the space area and density.\n');
 end
 ninst = size(Z,1);
 nalgos = size(Ybin,2);
@@ -41,16 +41,16 @@ if opts.Trace2
 else
     out.space = TRACEbuild(Z, true(ninst,1), opts);
 end
-disp(['    -> Space area: ' num2str(out.space.area) ...
-      ' | Space density: ' num2str(out.space.density)]);
+fprintf('    -> Space area: %s | Space density: %s\n', ...
+    num2str(out.space.area), num2str(out.space.density));
 % -------------------------------------------------------------------------
 % This loop will calculate the footprints for good/bad instances and the
 % best algorithm.
-disp('-------------------------------------------------------------------------');
+fprintf('-------------------------------------------------------------------------\n');
 if opts.Trace2
-    disp('  -> TRACE2 is calculating the algorithm footprints.');
+    fprintf('  -> TRACE2 is calculating the algorithm footprints.\n');
 else
-    disp('  -> TRACE is calculating the algorithm footprints.');
+    fprintf('  -> TRACE is calculating the algorithm footprints.\n');
 end
 
 good = cell(1,nalgos);
@@ -59,54 +59,53 @@ best = cell(1,nalgos);
 parfor (i=1:nalgos,nworkers)
     tic;
     if opts.Trace2
-        disp(['    -> Good performance footprint for ''' algolabels{i} '''']);
+        fprintf('    -> Good performance footprint for ''%s''\n', algolabels{i});
         good{i} = TRACEbuild2(Z, Ybin(:,i), opts);
-        disp(['    -> Best performance footprint for ''' algolabels{i} '''']);
+        fprintf('    -> Best performance footprint for ''%s''\n', algolabels{i});
         best{i} = TRACEbuild2(Z, P==i, opts);
     else
-        disp(['    -> Good performance footprint for ''' algolabels{i} '''']);
+        fprintf('    -> Good performance footprint for ''%s''\n', algolabels{i});
         good{i} = TRACEbuild(Z, Ybin(:,i), opts);
-        disp(['    -> Best performance footprint for ''' algolabels{i} '''']);
+        fprintf('    -> Best performance footprint for ''%s''\n', algolabels{i});
         best{i} = TRACEbuild(Z, P==i, opts);
     end
-    disp(['    -> Algorithm ''' algolabels{i} ''' completed. Elapsed time: ' num2str(toc,'%.2f\n') 's']);
+    fprintf('    -> Algorithm ''%s'' completed. Elapsed time: %.2fs\n', algolabels{i}, toc);
 end
 out.good = good;
 out.best = best;
 % -------------------------------------------------------------------------
 % Detecting collisions and removing them. Original Trace ONLY
 if ~opts.Trace2
-    disp('-------------------------------------------------------------------------');
-    disp('  -> TRACE is detecting and removing contradictory sections of the footprints.');
+    fprintf('-------------------------------------------------------------------------\n');
+    fprintf('  -> TRACE is detecting and removing contradictory sections of the footprints.\n');
     for i=1:nalgos
-        disp(['  -> Base algorithm ''' algolabels{i} '''']);
+        fprintf('  -> Base algorithm ''%s''\n', algolabels{i});
         startBase = tic;
         for j=i+1:nalgos
-            disp(['      -> TRACE is comparing ''' algolabels{i} ''' with ''' algolabels{j} '''']);
+            fprintf('      -> TRACE is comparing ''%s'' with ''%s''\n', algolabels{i}, algolabels{j});
             startTest = tic;
             [out.best{i}, out.best{j}] = TRACEcontra(out.best{i}, out.best{j}, ...
-                                                     Z, P==i, P==j, opts);%, false);
-
-            disp(['      -> Test algorithm ''' algolabels{j} ...
-                  ''' completed. Elapsed time: ' num2str(toc(startTest),'%.2f\n') 's']);
+                                                     Z, P==i, P==j, opts);
+            fprintf('      -> Test algorithm ''%s'' completed. Elapsed time: %.2fs\n', ...
+                algolabels{j}, toc(startTest));
         end
-        disp(['  -> Base algorithm ''' algolabels{i} ...
-              ''' completed. Elapsed time: ' num2str(toc(startBase),'%.2f\n') 's']);
+        fprintf('  -> Base algorithm ''%s'' completed. Elapsed time: %.2fs\n', ...
+            algolabels{i}, toc(startBase));
     end
 end
 % -------------------------------------------------------------------------
 % Beta hard footprints. First step is to calculate them.
-disp('-------------------------------------------------------------------------');
+fprintf('-------------------------------------------------------------------------\n');
 if opts.Trace2
-    disp('  -> TRACE2 is calculating the beta-footprint.');
+    fprintf('  -> TRACE2 is calculating the beta-footprint.\n');
 else
-    disp('  -> TRACE is calculating the beta-footprint.');
+    fprintf('  -> TRACE is calculating the beta-footprint.\n');
 end
 out.hard = TRACEbuild(Z, ~beta, opts);
 % -------------------------------------------------------------------------
 % Calculating performance
-disp('-------------------------------------------------------------------------');
-disp('  -> Preparing the summary table.');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('  -> Preparing the summary table.\n');
 out.summary = cell(nalgos+1,11);
 out.summary(1,2:end) = {'Area_Good',...
                         'Area_Good_Normalized',...
@@ -125,11 +124,11 @@ for i=1:nalgos
     out.summary(i+1,2:end) = num2cell(round(row,3));
 end
 if opts.Trace2
-    disp('  -> TRACE2 has completed. Footprint analysis results:');
+    fprintf('  -> TRACE2 has completed. Footprint analysis results:\n');
 else
-    disp('  -> TRACE has completed. Footprint analysis results:');
+    fprintf('  -> TRACE has completed. Footprint analysis results:\n');
 end
-disp(' ');
+fprintf('\n');
 disp(out.summary);
 
 end
@@ -280,23 +279,21 @@ while contradiction.NumRegions~=0 && numtries<=maxtries
     purityTest = numGoodElementsTest/numElements;
     if purityBase>purityTest %&& (~isbin || (purityBase>0.55 && isbin))
         carea = area(contradiction)./area(test.polygon);
-        disp(['        -> ' num2str(round(100.*carea,1)) '%' ...
-              ' of the test footprint is contradictory.']);
+        fprintf('        -> %.1f%% of the test footprint is contradictory.\n', round(100.*carea,1));
         test.polygon = subtract(test.polygon,contradiction);
         if numtries<maxtries
             test.polygon = TRACEtight(test.polygon,Z,Ytest,opts);
         end
     elseif purityTest>purityBase %&& (~isbin || (purityTest>0.55 && isbin))
         carea = area(contradiction)./area(base.polygon);
-        disp(['        -> ' num2str(round(100.*carea,1)) '%' ...
-              ' of the base footprint is contradictory.']);
+        fprintf('        -> %.1f%% of the base footprint is contradictory.\n', round(100.*carea,1));
         base.polygon = subtract(base.polygon,contradiction);
         if numtries<maxtries
             base.polygon = TRACEtight(base.polygon,Z,Ybase,opts);
         end
     else
-        disp('        -> Purity of the contradicting areas is equal for both footprints.');
-        disp('        -> Ignoring the contradicting area.');
+        fprintf('        -> Purity of the contradicting areas is equal for both footprints.\n');
+        fprintf('        -> Ignoring the contradicting area.\n');
         break;
     end
     if isempty(base.polygon) || isempty(test.polygon)
@@ -405,8 +402,8 @@ end
 % =========================================================================
 function footprint = TRACEthrow
 
-disp('        -> There are not enough instances to calculate a footprint.');
-disp('        -> The subset of instances used is too small.');
+fprintf('        -> There are not enough instances to calculate a footprint.\n');
+fprintf('        -> The subset of instances used is too small.\n');
 footprint.polygon = [];
 footprint.area = 0;
 footprint.elements = 0;

--- a/buildIS.m
+++ b/buildIS.m
@@ -15,33 +15,35 @@ startProcess = tic;
 scriptdisc('buildIS.m');
 % -------------------------------------------------------------------------
 % Collect all the data from the files
-disp(['Root Directory: ' rootdir]);
+fprintf('Root Directory: %s\n', rootdir);
 datafile = [rootdir 'metadata.csv'];
 optsfile = [rootdir 'options.json'];
 if ~isfile(datafile) || ~isfile(optsfile)
     error(['Please place the datafiles in the directory ''' rootdir '''']);
 end
 opts = jsondecode(fileread(optsfile));
-disp('-------------------------------------------------------------------------');
-disp('-> Listing options to be used:');
-optfields = fieldnames(opts);
-for i = 1:length(optfields)
-    disp(optfields{i});
-    disp(opts.(optfields{i}));
-end
-useparallel = isfield(opts,'parallel') && isfield(opts.parallel,'flag') && opts.parallel.flag;
-if useparallel
-    disp('-------------------------------------------------------------------------');
-    disp('-> Starting parallel processing pool.');
-    delete(gcp('nocreate'));
-    if  isfield(opts.parallel,'ncores') && isnumeric(opts.parallel.ncores)
-        mypool = parpool('local',opts.parallel.ncores,'SpmdEnabled',false);
-    else
-        mypool = parpool('local','SpmdEnabled',false);
+opts = ISAdefaults(opts);
+if opts.general.verbose
+    fprintf('-------------------------------------------------------------------------\n');
+    fprintf('-> Listing options to be used:\n');
+    optfields = fieldnames(opts);
+    for i = 1:length(optfields)
+        fprintf('%s\n', optfields{i});
+        disp(opts.(optfields{i}));
     end
 end
-disp('-------------------------------------------------------------------------');
-disp('-> Loading the data.');
+if opts.parallel.flag
+    fprintf('-------------------------------------------------------------------------\n');
+    fprintf('-> Starting parallel processing pool.\n');
+    delete(gcp('nocreate'));
+    if isnumeric(opts.parallel.ncores)
+        mypool = parpool('local', opts.parallel.ncores, 'SpmdEnabled', false);
+    else
+        mypool = parpool('local', 'SpmdEnabled', false);
+    end
+end
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('-> Loading the data.\n');
 Xbar = readtable(datafile);
 varlabels = Xbar.Properties.VariableNames;
 isname = strcmpi(varlabels,'instances');
@@ -63,32 +65,31 @@ model.data.Y = Xbar{:,isalgo};
 % work with
 model.data.featlabels = varlabels(isfeat);
 if isfield(opts,'selvars') && isfield(opts.selvars,'feats')
-    disp('-------------------------------------------------------------------------');
+    fprintf('-------------------------------------------------------------------------\n');
     msg = '-> Using the following features: ';
     isselfeat = false(1,length(model.data.featlabels));
     for i=1:length(opts.selvars.feats)
         isselfeat = isselfeat | strcmp(model.data.featlabels,opts.selvars.feats{i});
         msg = [msg opts.selvars.feats{i} ' ']; %#ok<AGROW>
     end
-    disp(msg);
+    fprintf('%s\n', msg);
     model.data.X = model.data.X(:,isselfeat);
     model.data.featlabels = model.data.featlabels(isselfeat);
 end
 
 model.data.algolabels = varlabels(isalgo);
 if isfield(opts,'selvars') && isfield(opts.selvars,'algos')
-    disp('-------------------------------------------------------------------------');
+    fprintf('-------------------------------------------------------------------------\n');
     msg = '-> Using the following algorithms: ';
     isselalgo = false(1,length(model.data.algolabels));
     for i=1:length(opts.selvars.algos)
         isselalgo = isselalgo | strcmp(model.data.algolabels,opts.selvars.algos{i});
         msg = [msg opts.selvars.algos{i} ' ']; %#ok<AGROW>
     end
-    disp(msg);
+    fprintf('%s\n', msg);
     model.data.Y = model.data.Y(:,isselalgo);
     model.data.algolabels = model.data.algolabels(isselalgo);
 end
-% nalgos = size(model.data.Y,2);
 % -------------------------------------------------------------------------
 % PROBABLY HERE SHOULD DO A SANITY CHECK, I.E., IS THERE TOO MANY NANS?
 idx = all(isnan(model.data.X),2) | all(isnan(model.data.Y),2);
@@ -145,48 +146,36 @@ if any(idx)
 end
 % -------------------------------------------------------------------------
 % If we are only meant to take some observations
-disp('-------------------------------------------------------------------------');
+fprintf('-------------------------------------------------------------------------\n');
 ninst = size(model.data.X,1);
-fractional = isfield(opts,'selvars') && ...
-             isfield(opts.selvars,'smallscaleflag') && ...
-             opts.selvars.smallscaleflag && ...
-             isfield(opts.selvars,'smallscale') && ...
-             isfloat(opts.selvars.smallscale);
-fileindexed = isfield(opts,'selvars') && ...
-              isfield(opts.selvars,'fileidxflag') && ...
-              opts.selvars.fileidxflag && ...
-              isfield(opts.selvars,'fileidx') && ...
-              isfile(opts.selvars.fileidx);
-bydensity = isfield(opts,'selvars') && ...
-            isfield(opts.selvars,'densityflag') && ...
-            opts.selvars.densityflag && ...
-            isfield(opts.selvars,'mindistance') && ...
-            isfloat(opts.selvars.mindistance) && ...
-            isfield(opts.selvars,'type') && ...
-            ischar(opts.selvars.type);
+fractional = opts.selvars.smallscaleflag && isfloat(opts.selvars.smallscale);
+fileindexed = opts.selvars.fileidxflag && isfile(opts.selvars.fileidx);
+bydensity   = opts.selvars.densityflag && ...
+              isfloat(opts.selvars.mindistance) && ...
+              ischar(opts.selvars.type);
 if fractional
-    disp(['-> Creating a small scale experiment for validation. Percentage of subset: ' ...
-        num2str(round(100.*opts.selvars.smallscale,2)) '%']);
+    fprintf('-> Creating a small scale experiment for validation. Percentage of subset: %s%%\n', ...
+        num2str(round(100.*opts.selvars.smallscale,2)));
     state = rng;
     rng('default');
     aux = cvpartition(ninst,'HoldOut',opts.selvars.smallscale);
     rng(state);
     subsetIndex = aux.test;
 elseif fileindexed
-    disp('-> Using a subset of the instances.');
+    fprintf('-> Using a subset of the instances.\n');
     subsetIndex = false(size(model.data.X,1),1);
     aux = table2array(readtable(opts.selvars.fileidx));
     aux(aux>ninst) = [];
     subsetIndex(aux) = true;
 elseif bydensity
-    disp('-> Creating a small scale experiment for validation based on density.');
+    fprintf('-> Creating a small scale experiment for validation based on density.\n');
     subsetIndex = FILTER(model.data.X, model.data.Y, model.data.Ybin, ...
                          opts.selvars);
     subsetIndex = ~subsetIndex;
-    disp(['-> Percentage of instances retained: ' ...
-          num2str(round(100.*mean(subsetIndex),2)) '%']);
+    fprintf('-> Percentage of instances retained: %s%%\n', ...
+        num2str(round(100.*mean(subsetIndex),2)));
 else
-    disp('-> Using the complete set of the instances.');
+    fprintf('-> Using the complete set of the instances.\n');
     subsetIndex = true(ninst,1);
 end
 
@@ -194,19 +183,7 @@ if fileindexed || fractional || bydensity
     if bydensity
         model.data_dense = model.data;
     end
-    model.data.X = model.data.X(subsetIndex,:);
-    model.data.Y = model.data.Y(subsetIndex,:);
-    model.data.Xraw = model.data.Xraw(subsetIndex,:);
-    model.data.Yraw = model.data.Yraw(subsetIndex,:);
-    model.data.Ybin = model.data.Ybin(subsetIndex,:);
-    model.data.beta = model.data.beta(subsetIndex);
-    model.data.numGoodAlgos = model.data.numGoodAlgos(subsetIndex);
-    model.data.Ybest = model.data.Ybest(subsetIndex); 
-    model.data.P = model.data.P(subsetIndex);
-    model.data.instlabels = model.data.instlabels(subsetIndex);
-    if isfield(model.data,'S')
-        model.data.S = model.data.S(subsetIndex);
-    end
+    model.data = ISAsubsetData(model.data, subsetIndex);
 end
 nfeats = size(model.data.X,2);
 % -------------------------------------------------------------------------
@@ -215,107 +192,88 @@ nfeats = size(model.data.X,2);
 % later
 model.featsel.idx = 1:nfeats;
 if opts.sifted.flag
-    disp('=========================================================================');
-    disp('-> Calling SIFTED for auto-feature selection.');
-    disp('=========================================================================');
-    % [model.data.X, model.sifted] = SIFTED(model.data.X, model.data.Y, model.data.Ybin, opts.sifted);
+    fprintf('=========================================================================\n');
+    fprintf('-> Calling SIFTED for auto-feature selection.\n');
+    fprintf('=========================================================================\n');
     [model.data.X, model.sifted] = SIFTED2(model.data.X, model.data.Y, model.data.Ybin, model.data.featlabels, opts.sifted);
     model.data.featlabels = model.data.featlabels(model.sifted.selvars);
     model.featsel.idx = model.featsel.idx(model.sifted.selvars);
 
     if bydensity
-        disp('-> Creating a small scale experiment for validation based on density.');
-        % model.data.featlabels = model.data_dense.featlabels(model.sifted.selvars);
+        fprintf('-> Creating a small scale experiment for validation based on density.\n');
         subsetIndex = FILTER(model.data_dense.X(:,model.featsel.idx), ...
                              model.data_dense.Y, ...
                              model.data_dense.Ybin, ...
                              opts.selvars);
         subsetIndex = ~subsetIndex;
-        model.data.X = model.data_dense.X(subsetIndex,model.featsel.idx);
-        model.data.Y = model.data_dense.Y(subsetIndex,:);
-        model.data.Xraw = model.data_dense.Xraw(subsetIndex,:);
-        model.data.Yraw = model.data_dense.Yraw(subsetIndex,:);
-        model.data.Ybin = model.data_dense.Ybin(subsetIndex,:);
-        model.data.beta = model.data_dense.beta(subsetIndex);
-        model.data.numGoodAlgos = model.data_dense.numGoodAlgos(subsetIndex);
-        model.data.Ybest = model.data_dense.Ybest(subsetIndex);
-        model.data.P = model.data_dense.P(subsetIndex);
-        model.data.instlabels = model.data_dense.instlabels(subsetIndex);
-        if isfield(model.data_dense,'S')
-            model.data.S = model.data_dense.S(subsetIndex);
-        end
-        disp(['-> Percentage of instances retained: ' ...
-              num2str(round(100.*mean(subsetIndex),2)) '%']);
+        model.data = ISAsubsetData(model.data_dense, subsetIndex, model.featsel.idx);
+        fprintf('-> Percentage of instances retained: %s%%\n', ...
+            num2str(round(100.*mean(subsetIndex),2)));
     end
 end
 % -------------------------------------------------------------------------
 % This is the final subset of features. Calculate the two dimensional
 % projection using the PILOT algorithm (Munoz et al. Mach Learn 2018)
-disp('=========================================================================');
-disp('-> Calling PILOT to find the optimal projection.');
-disp('=========================================================================');
+fprintf('=========================================================================\n');
+fprintf('-> Calling PILOT to find the optimal projection.\n');
+fprintf('=========================================================================\n');
 model.pilot = PILOT(model.data.X, model.data.Y, model.data.featlabels, opts.pilot);
 % -------------------------------------------------------------------------
 % Finding the empirical bounds based on the ranges of the features and the
 % correlations of the different edges.
-disp('=========================================================================');
-disp('-> Finding empirical bounds using CLOISTER.');
-disp('=========================================================================');
+fprintf('=========================================================================\n');
+fprintf('-> Finding empirical bounds using CLOISTER.\n');
+fprintf('=========================================================================\n');
 model.cloist = CLOISTER(model.data.X, model.pilot.A, opts.cloister);
 % -------------------------------------------------------------------------
 % Algorithm selection. Fit a model that would separate the space into
-% classes of good and bad performance. 
-disp('=========================================================================');
-disp('-> Summoning PYTHIA to train the prediction models.');
-disp('=========================================================================');
-if isfield(opts.pythia,'useknn') && opts.pythia.useknn
+% classes of good and bad performance.
+fprintf('=========================================================================\n');
+fprintf('-> Summoning PYTHIA to train the prediction models.\n');
+fprintf('=========================================================================\n');
+if opts.pythia.useknn
     model.pythia = PYTHIA2(model.pilot.Z, model.data.Yraw, model.data.Ybin, model.data.Ybest, model.data.algolabels, opts.pythia);
 else
     model.pythia = PYTHIA(model.pilot.Z, model.data.Yraw, model.data.Ybin, model.data.Ybest, model.data.algolabels, opts.pythia);
 end
 % -------------------------------------------------------------------------
 % Calculating the algorithm footprints.
-disp('=========================================================================');
-disp('-> Calling TRACE to perform the footprint analysis.');
-disp('=========================================================================');
+fprintf('=========================================================================\n');
+fprintf('-> Calling TRACE to perform the footprint analysis.\n');
+fprintf('=========================================================================\n');
 if opts.trace.usesim
-    disp('  -> TRACE will use PYTHIA''s results to calculate the footprints.');
+    fprintf('  -> TRACE will use PYTHIA''s results to calculate the footprints.\n');
     model.trace = TRACE(model.pilot.Z, model.pythia.Yhat, model.pythia.selection0, model.data.beta, model.data.algolabels, opts.trace);
 else
-    disp('  -> TRACE will use experimental data to calculate the footprints.');
+    fprintf('  -> TRACE will use experimental data to calculate the footprints.\n');
     model.trace = TRACE(model.pilot.Z, model.data.Ybin, model.data.P, model.data.beta, model.data.algolabels, opts.trace);
 end
 
-if useparallel
-    disp('-------------------------------------------------------------------------');
-    disp('-> Closing parallel processing pool.');
+if opts.parallel.flag
+    fprintf('-------------------------------------------------------------------------\n');
+    fprintf('-> Closing parallel processing pool.\n');
     delete(mypool);
 end
 % -------------------------------------------------------------------------
 % Preparing the outputs for further analysis
 model.opts = opts;
 % -------------------------------------------------------------------------
-disp('-------------------------------------------------------------------------');
-disp('-> Storing the raw MATLAB results for post-processing and/or debugging.');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('-> Storing the raw MATLAB results for post-processing and/or debugging.\n');
 save([rootdir 'model.mat'],'-struct','model'); % Save the main results
 save([rootdir 'workspace.mat']); % Save the full workspace for debugging
 % -------------------------------------------------------------------------
 if opts.outputs.csv
-    % Storing the output data as a CSV files. This is for easier
-    % post-processing. All workspace data will be stored in a matlab file
-    % later.
     scriptcsv(model,rootdir);
     if opts.outputs.web
         scriptweb(model,rootdir);
     end
 end
 % -------------------------------------------------------------------------
-% Making all the plots. First, plotting the features and performance as
-% scatter plots.
 if opts.outputs.png
     scriptpng(model,rootdir);
 end
 % -------------------------------------------------------------------------
-disp(['-> Completed! Elapsed time: ' num2str(toc(startProcess)) 's']);
-disp('EOF:SUCCESS');
+fprintf('-> Completed! Elapsed time: %ss\n', num2str(toc(startProcess)));
+fprintf('EOF:SUCCESS\n');
 end

--- a/exploreIS.m
+++ b/exploreIS.m
@@ -15,22 +15,25 @@ startProcess = tic;
 scriptdisc('exploreIS.m');
 % -------------------------------------------------------------------------
 % Collect all the data from the files
-disp(['Root Directory: ' rootdir]);
+fprintf('Root Directory: %s\n', rootdir);
 modelfile = [rootdir 'model.mat'];
 datafile = [rootdir 'metadata_test.csv'];
 if ~isfile(modelfile) || ~isfile(datafile)
     error(['Please place the datafiles in the directory ''' rootdir '''']);
 end
 model = load(modelfile);
-disp('-------------------------------------------------------------------------');
-disp('Listing options used:');
-optfields = fieldnames(model.opts);
-for i = 1:length(optfields)
-    disp(optfields{i});
-    disp(model.opts.(optfields{i}));
+model.opts = ISAdefaults(model.opts);
+if model.opts.general.verbose
+    fprintf('-------------------------------------------------------------------------\n');
+    fprintf('Listing options used:\n');
+    optfields = fieldnames(model.opts);
+    for i = 1:length(optfields)
+        fprintf('%s\n', optfields{i});
+        disp(model.opts.(optfields{i}));
+    end
 end
-disp('-------------------------------------------------------------------------');
-disp('-> Loading the data');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('-> Loading the data\n');
 Xbar = readtable(datafile);
 varlabels = Xbar.Properties.VariableNames;
 isname = strcmpi(varlabels,'instances');
@@ -73,7 +76,6 @@ for ii=1:nalgos
        acc = acc+1;
     else
         Yaux(:,algoexist(ii)) = out.data.Y(:,ii);
-        % lblaux(:,acc) = out.data.algolabels(ii);
     end
 end
 out.data.Y = Yaux;
@@ -90,8 +92,8 @@ out.data.Yraw = out.data.Y;
 % algorithm has a performance better than the threshold) or a relative
 % performance (the algorithm has a performance that is similar that the
 % best algorithm minus a percentage).
-disp('-------------------------------------------------------------------------');
-disp('-> Calculating the binary measure of performance');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('-> Calculating the binary measure of performance\n');
 msg = '-> An algorithm is good if its performace is ';
 MaxPerf = false;
 if isfield(model.opts.perf, 'MaxPerf')
@@ -134,17 +136,17 @@ else
         msg = [msg 'within ' num2str(round(100.*model.opts.perf.epsilon)) '% of the best.'];
     end
 end
-disp(msg);
+fprintf('%s\n', msg);
 out.data.numGoodAlgos = sum(out.data.Ybin,2);
 out.data.beta = out.data.numGoodAlgos>model.opts.perf.betaThreshold*nalgos;
 % ---------------------------------------------------------------------
 % Automated pre-processing
 if model.opts.auto.preproc && model.opts.bound.flag
-    disp('-------------------------------------------------------------------------');
-    disp('-> Auto-pre-processing. Bounding outliers, scaling and normalizing the data.');
+    fprintf('-------------------------------------------------------------------------\n');
+    fprintf('-> Auto-pre-processing. Bounding outliers, scaling and normalizing the data.\n');
     % Eliminate extreme outliers, i.e., any point that exceedes 5 times the
     % inter quantile range, by bounding them to that value.
-    disp('-> Removing extreme outliers from the feature values.');
+    fprintf('-> Removing extreme outliers from the feature values.\n');
     himask = bsxfun(@gt,out.data.X,model.bound.hibound);
     lomask = bsxfun(@lt,out.data.X,model.bound.lobound);
     out.data.X = out.data.X.*~(himask | lomask) + bsxfun(@times,himask,model.bound.hibound) + ...
@@ -153,13 +155,13 @@ end
 
 if model.opts.auto.preproc && model.opts.norm.flag
     % Normalize the data using Box-Cox and out.pilot.Z-transformations
-    disp('-> Auto-normalizing the data.');
+    fprintf('-> Auto-normalizing the data.\n');
     out.data.X = bsxfun(@minus,out.data.X,model.norm.minX)+1;
     for ii=1:length(model.norm.lambdaX)
         out.data.X(:,ii) = boxcox(out.data.X(:,ii),model.norm.lambdaX(:,ii));
     end
     out.data.X = bsxfun(@rdivide,bsxfun(@minus,out.data.X,model.norm.muX),model.norm.sigmaX);
-    
+
     % If the algorithm is new, something else should be made...
     out.data.Y(out.data.Y==0) = eps; % Assumes that out.data.Y is always positive and higher than 1e-16
     for ii=1:modelalgos
@@ -183,7 +185,7 @@ out.data.featlabels = out.data.featlabels(model.featsel.idx);
 out.pilot.Z = out.data.X*model.pilot.A';
 % -------------------------------------------------------------------------
 % Algorithm selection. Fit a model that would separate the space into
-% classes of good and bad performance. 
+% classes of good and bad performance.
 out.pythia = PYTHIAtest(model.pythia, out.pilot.Z, out.data.Yraw, ...
                         out.data.Ybin, out.data.Ybest, ...
                         out.data.algolabels);
@@ -193,14 +195,10 @@ if model.opts.trace.usesim
     out.trace = TRACEtest(model.trace, out.pilot.Z, out.pythia.Yhat, ...
                           out.pythia.selection0, out.data.beta, ...
                           out.data.algolabels);
-%     out.trace = TRACE(out.pilot.Z, out.pythia.Yhat, out.pythia.selection0, ...
-%                       out.data.beta, out.data.algolabels, model.opts.trace);
 else
     out.trace = TRACEtest(model.trace, out.pilot.Z, out.data.Ybin, ...
                           out.data.P, out.data.beta, ...
                           out.data.algolabels);
-%     out.trace = TRACE(out.pilot.Z, out.data.Ybin, out.data.P, out.data.beta,...
-%                       out.data.algolabels, model.opts.trace);
 end
 
 out.opts = model.opts;
@@ -217,10 +215,10 @@ if model.opts.outputs.png
     scriptpng(out,rootdir);
 end
 
-disp('-------------------------------------------------------------------------');
-disp('-> Storing the raw MATLAB results for post-processing and/or debugging.');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('-> Storing the raw MATLAB results for post-processing and/or debugging.\n');
 save([rootdir 'workspace_test.mat']); % Save the full workspace for debugging
-disp(['-> Completed! Elapsed time: ' num2str(toc(startProcess)) 's']);
-disp('EOF:SUCCESS');
+fprintf('-> Completed! Elapsed time: %ss\n', num2str(toc(startProcess)));
+fprintf('EOF:SUCCESS\n');
 end
 % =========================================================================

--- a/options.json
+++ b/options.json
@@ -1,1 +1,18 @@
-{"perf":{"MaxPerf":false,"AbsPerf":false,"epsilon":0.05},"general":{"betaThreshold":0.55},"auto":{"preproc":true,"featsel":true},"bound":{"flag":true},"norm":{"flag":true},"diversity":{"flag":false,"threshold":0.3},"corr":{"flag":true,"threshold":3},"clust":{"flag":true,"KDEFAULT":10,"SILTHRESHOLD":0.45,"NTREES":50,"MaxIter":1000,"Replicates":100},"pbldr":{"analytic":false,"ntries":10},"sbound":{"pval":0.05,"cthres":0.7},"oracle":{"cvgrid":10,"maxcvgrid":5,"mincvgrid":-5,"cvfolds":5},"footprint":{"usesim":false,"RHO":10,"PI":0.75,"PCTILE":0.3},"selvars":{"smallscaleflag":false,"smallscale":0.3,"fileidxflag":false,"fileidx":""},"outputs":{"csv":true,"web":false,"png":true}}
+{
+  "general":  {"seed": 42, "verbose": true},
+  "perf":     {"MaxPerf": false, "AbsPerf": false, "epsilon": 0.05, "betaThreshold": 0.55},
+  "auto":     {"preproc": true},
+  "bound":    {"flag": true},
+  "norm":     {"flag": true},
+  "selvars":  {"smallscaleflag": false, "smallscale": 0.3,
+               "fileidxflag": false, "fileidx": "",
+               "densityflag": false, "mindistance": 0.1, "type": "Ftr&Good"},
+  "sifted":   {"flag": true, "rho": 0.1, "K": 10, "NTREES": 50,
+               "MaxIter": 1000, "Replicates": 100},
+  "pilot":    {"analytic": false, "ntries": 10},
+  "cloister": {"pval": 0.05, "cthres": 0.7},
+  "pythia":   {"cvfolds": 5},
+  "trace":    {"usesim": false, "PI": 0.75, "RHO": 10},
+  "outputs":  {"csv": true, "png": true, "web": false},
+  "parallel": {"flag": false, "ncores": 18}
+}


### PR DESCRIPTION
## Summary

- **`ISAdefaults.m`** (new): fills all 35+ opts fields across every pipeline function with documented defaults; adds `general.seed=42` and `general.verbose=true`; propagates `verbose` into `opts.pilot` and `opts.pythia` sub-structs, eliminating all scattered `isfield` chains.
- **`ISAsubsetData.m`** (new): extracts the repeated 10-field row-subset block from `buildIS.m`; accepts an optional `featIdx` argument for the post-SIFTED density path.
- **`options.json`**: renamed legacy fields (`pbldr→pilot`, `sbound→cloister`, `oracle→pythia`, `footprint→trace`); moved `betaThreshold` into `perf`; added `general.seed` and `general.verbose`.
- **`buildIS.m`**: calls `ISAdefaults` after `jsondecode`; gates opts listing behind `verbose`; collapses all `isfield` chains; both subset blocks replaced with `ISAsubsetData`; PYTHIA dispatch simplified; `disp→fprintf` throughout.
- **`exploreIS.m`**: calls `ISAdefaults(model.opts)` to backfill missing fields in loaded models; gates opts listing; `disp→fprintf`.
- **`PRELIM`, `SIFTED2`, `CLOISTER`**: `disp→fprintf` throughout.
- **`PILOT.m`**: `disp→fprintf`; per-trial progress gated behind `opts.verbose`.
- **`PYTHIA.m`**: `disp→fprintf`; per-algorithm training messages gated behind `opts.verbose`.
- **`TRACE.m`**: `disp→fprintf` in all subfunctions including `TRACEcontra` and `TRACEthrow`.

Summary cell arrays and numeric tables intentionally retained as `disp`. Stage tags (`[PILOT]` etc.) deferred to Phase 7. `ISAvalidateOpts` deferred to Phase 7.

## Open questions resolved
- `ISAdefaults` scope: covers **all** opts fields across all pipeline functions (not just top-level `buildIS` ones).
- Stage tags: deferred to Phase 7.
- `ISAvalidateOpts`: deferred to Phase 7.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111NcMAWwUUK3oGwfsb5yCp)_