### PR TITLE
TRACE.m: collapse redundant is3D branch around convhull(Z)

### DIFF
--- a/core/TRACE.m
+++ b/core/TRACE.m
@@ -89,11 +89,10 @@ pythiaAvailable = ~isempty(Yhat) && ~pythiaSkipped;
 % -------------------------------------------------------------------------
 % Space measure from convex hull of all instances (computed once).
 % Passed to TRACEbuild3 so stopping criteria are relative to bounded space.
-if is3D
-    [~, spaceArea] = convhull(Z);
-else
-    [~, spaceArea] = convhull(Z(:,1), Z(:,2));
-end
+% convhull(Z) accepts Z directly as an n-by-2 or n-by-3 points matrix, so
+% no is3D branch is needed here (unlike TRACEmetrics3's area()/volume()
+% calls below, which really do need to dispatch on dimensionality).
+[~, spaceArea] = convhull(Z);
 if is3D; measureLabel = 'Volume'; else; measureLabel = 'Area'; end
 
 % =========================================================================


### PR DESCRIPTION
convhull(P) accepts a single n-by-2 or n-by-3 points matrix directly, so branching between convhull(Z) and convhull(Z(:,1),Z(:,2)) produced identical results either way -- pure redundancy, not a correctness issue. Collapsed to one call.


Claude-Session: https://claude.ai/code/session_0111NcMAWwUUK3oGwfsb5yCp