### PR TITLE
utils/ISAvalidateOpts.m: skip [0,1] range check on perf.epsilon when AbsPerf=true

### DIFF
--- a/utils/ISAvalidateOpts.m
+++ b/utils/ISAvalidateOpts.m
@@ -68,7 +68,13 @@ checkLogical(opts, 'perf', 'AbsPerf');
 % is compared directly against the raw performance measure (PRELIM.m), so
 % it carries that measure's units and can be any real number.
 [absPerf, absPerfPresent] = getf(opts, 'perf', 'AbsPerf');
-if ~(absPerfPresent && absPerf)
+if absPerfPresent && absPerf
+    [epsVal, epsPresent] = getf(opts, 'perf', 'epsilon');
+    if epsPresent && ~(isnumeric(epsVal) && isscalar(epsVal) && isreal(epsVal) && isfinite(epsVal))
+        error('ISA:ISAvalidateOpts:notFiniteNumericScalar', ...
+            'opts.perf.epsilon must be a finite numeric real scalar when opts.perf.AbsPerf=true; got %s.', describe(epsVal));
+    end
+else
     checkUnitRange(opts, 'perf', 'epsilon');
 end
 checkUnitRange(opts, 'perf', 'betaThreshold');

--- a/utils/ISAvalidateOpts.m
+++ b/utils/ISAvalidateOpts.m
@@ -63,7 +63,14 @@ end
 
 checkLogical(opts, 'perf', 'MaxPerf');
 checkLogical(opts, 'perf', 'AbsPerf');
-checkUnitRange(opts, 'perf', 'epsilon');
+% epsilon is only a [0,1] fraction when performance is relative (compared
+% against a normalized ratio to the best algorithm); under AbsPerf=true it
+% is compared directly against the raw performance measure (PRELIM.m), so
+% it carries that measure's units and can be any real number.
+[absPerf, absPerfPresent] = getf(opts, 'perf', 'AbsPerf');
+if ~(absPerfPresent && absPerf)
+    checkUnitRange(opts, 'perf', 'epsilon');
+end
 checkUnitRange(opts, 'perf', 'betaThreshold');
 
 checkPositive(opts, 'prelim', 'iqrMultiplier');


### PR DESCRIPTION
## Summary
- Fixes #47: `checkUnitRange(opts, 'perf', 'epsilon')` was applied unconditionally, but `epsilon` is only a `[0,1]` fraction under relative performance (`AbsPerf=false`). Under `AbsPerf=true`, `PRELIM.m` compares `epsilon` directly against the raw performance measure (`Yaux >= opts.epsilon` / `Yaux <= opts.epsilon`), so it carries that measure's units (e.g. runtime seconds) and can legitimately be any real number.
- The check is now skipped when `AbsPerf` is present and `true`; it still runs (correctly) when `AbsPerf` is absent (default `false`, per `ISAdefaults.m`) or explicitly `false`.
- Verified `betaThreshold`, validated on the following line, does NOT need the same guard — it's always compared against `numGoodAlgos/nalgos`, a genuine `[0,1]` fraction regardless of `AbsPerf`.
- Mirrors the existing conditional-validation pattern already used for `general.ncores` a few lines above (peek at a sibling field via `getf`, branch the check).

## Test plan
- [x] Confirmed the merge against current `master` is clean (dry-run, no conflicts).
- [ ] Manual MATLAB check: `opts.perf.AbsPerf = true; opts.perf.epsilon = 3600; ISAvalidateOpts(opts);` no longer errors.
- [ ] Manual MATLAB check: relative case (`AbsPerf` absent/false) with `epsilon` outside `[0,1]` still errors as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_0111NcMAWwUUK3oGwfsb5yCp)_